### PR TITLE
fix: make auto-approve actually work

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'DanielMSchmidt')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'team-tf-cdk')
     steps:
       - uses: hmarr/auto-approve-action@v2.2.1
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -73,7 +73,7 @@ jobs:
             *Automatically created by projen via the "upgrade-main" workflow*
           branch: github-actions/upgrade-main
           title: "chore(deps): upgrade dependencies"
-          labels: auto-approve
+          labels: auto-approve,dependencies
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -43,10 +43,15 @@ const project = new ConstructLibraryCdktf({
   prettier: true,
   projenrcTs: true,
   autoApproveOptions: {
-    allowedUsernames: ["DanielMSchmidt"],
+    allowedUsernames: ["team-tf-cdk"],
     label: "auto-approve",
   },
   autoApproveUpgrades: true,
+  depsUpgradeOptions: {
+    workflowOptions: {
+      labels: ["auto-approve", "dependencies"],
+    },
+  },
   publishToPypi: {
     distName: name,
     module: name.replace(/-/g, "_"),


### PR DESCRIPTION
Realized this wasn't working because our upgrade PRs come from team-tf-cdk and not github-actions[bot]
