### PR TITLE
chore: try Dependabot for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# NOTE: This file is not managed by Projen because if you enable Dependabot through Projen,
+# it will delete the upgrade-main job and expect you to only use Dependabot for updates.
+# That is not what we want either; we just want to use Dependabot for security updates.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    versioning-strategy: lockfile-only
+    directory: /
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: projen
+    labels:
+      - auto-approve
+      - automerge
+      - dependencies
+      - security
+    # Disable version updates for npm dependencies, only use Dependabot for security updates
+    open-pull-requests-limit: 0

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve')
     steps:
       - name: Checkout PR
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
@@ -21,12 +22,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Auto-approve PRs by other users as team-tf-cdk
-        if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login != 'team-tf-cdk')
+        if: github.event.pull_request.user.login != 'team-tf-cdk'
         env:
           GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
         run: gh pr review ${{ github.event.pull_request.number }} --approve
       - name: Auto-approve PRs by team-tf-cdk as github-actions[bot]
-        if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'team-tf-cdk')
+        if: github.event.pull_request.user.login == 'team-tf-cdk'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr review ${{ github.event.pull_request.number }} --approve

--- a/projenrc/auto-approve.ts
+++ b/projenrc/auto-approve.ts
@@ -24,6 +24,7 @@ export class AutoApprove {
     workflow.addJobs({
       approve: {
         runsOn: ["ubuntu-latest"],
+        if: "contains(github.event.pull_request.labels.*.name, 'auto-approve')",
         steps: [
           {
             name: "Checkout PR",
@@ -36,7 +37,7 @@ export class AutoApprove {
           },
           {
             name: "Auto-approve PRs by other users as team-tf-cdk",
-            if: "contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login != 'team-tf-cdk')",
+            if: "github.event.pull_request.user.login != 'team-tf-cdk'",
             run: "gh pr review ${{ github.event.pull_request.number }} --approve",
             env: {
               GH_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
@@ -44,7 +45,7 @@ export class AutoApprove {
           },
           {
             name: "Auto-approve PRs by team-tf-cdk as github-actions[bot]",
-            if: "contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'team-tf-cdk')",
+            if: "github.event.pull_request.user.login == 'team-tf-cdk'",
             run: "gh pr review ${{ github.event.pull_request.number }} --approve",
             env: {
               GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5918,9 +5918,9 @@ npm-bundled@^3.0.0:
     npm-normalize-package-bin "^3.0.0"
 
 npm-check-updates@^16:
-  version "16.12.2"
-  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-16.12.2.tgz#37d226da69b93b4d9aec820a6442b572e6a9f264"
-  integrity sha512-N0jeEcak3/+PS1O5JzwJ2+fvmQVv+084O4iRnDtcMBLcr9S7vPOBxwWgsEuNfj3shKFZRYOuh4NHB9nMenCHXA==
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-16.13.1.tgz#7aa0d24b180b6b7f4a881abff7d7150f0ca5a884"
+  integrity sha512-RIKBemiyAOEAUfzgYzDffLQwXI/Zo4CMSGHtup9fUoBpHqPNtD0pPFjpxDnt/sFpGiV5iANdE2Ck6xOxuQFfJg==
   dependencies:
     chalk "^5.3.0"
     cli-table3 "^0.6.3"


### PR DESCRIPTION
Security would like everyone to turn on Dependabot for security updates if possible. This is me trying this out for a Projen-based repo to see how well they play with each other.

See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file for more details.