### PR TITLE
chore: remove hard-coded dependency on jsii-docgen

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -79,7 +79,6 @@
     },
     {
       "name": "jsii-docgen",
-      "version": "^9.0.0",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -66,11 +66,7 @@ project.addPeerDeps(
   "@cdktf/provider-tfe@>=9.0.0",
   `constructs@${constructVersion}`
 );
-project.addDevDeps(
-  "ts-node@10.9.1",
-  `cdktf-cli@${cdktfVersion}`,
-  "jsii-docgen@^9.0.0"
-);
+project.addDevDeps("ts-node@10.9.1", `cdktf-cli@${cdktfVersion}`);
 
 project.testTask.exec(`npx cdktf synth`, {
   name: "synth TS example",


### PR DESCRIPTION
This will allow it to more easily be auto-updated in the future.